### PR TITLE
Matrix configurations with escaped characters in name cause error

### DIFF
--- a/src/main/java/hudson/plugins/build_publisher/HTTPBuildTransmitter.java
+++ b/src/main/java/hudson/plugins/build_publisher/HTTPBuildTransmitter.java
@@ -26,8 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import org.apache.commons.httpclient.HttpException;
@@ -45,7 +43,6 @@ public class HTTPBuildTransmitter implements BuildTransmitter {
             throws ServerFailureException {
 
         aborted = false;
-
         AbstractProject project = build.getProject();
         
         String jobUrl = "job/";
@@ -57,13 +54,13 @@ public class HTTPBuildTransmitter implements BuildTransmitter {
         } else if (project instanceof MatrixConfiguration) {
             jobUrl += ((MatrixConfiguration)project).getParent().getName()
                     + "/"
-                    + ((MatrixConfiguration)project).getCombination().toString();
+                    + Util.rawEncode(((MatrixConfiguration)project).getCombination().toString());
         } else {
             jobUrl += project.getName();
         }
 
         method = new PostMethod(hudsonInstance.getUrl()
-                + encodeURI(jobUrl) + "/postBuild/acceptBuild");
+                + jobUrl + "/postBuild/acceptBuild");
 
         File tempFile = null;
         OutputStream out = null;
@@ -276,15 +273,5 @@ public class HTTPBuildTransmitter implements BuildTransmitter {
 
         in.close();
     }
-
-    public static String encodeURI(String uri) {
-        try {
-            return new URI(null,uri,null).toASCIIString();
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-            return uri;
-        }
-    }
-
 
 }

--- a/src/main/java/hudson/plugins/build_publisher/PublisherThread.java
+++ b/src/main/java/hudson/plugins/build_publisher/PublisherThread.java
@@ -247,9 +247,7 @@ public class PublisherThread extends Thread {
 
     private void submitConfig(String submitConfigUrl, Job project)
             throws IOException, ServerFailureException {
-        PostMethod method = new PostMethod();
-        method.setURI(new org.apache.commons.httpclient.URI(submitConfigUrl,
-                                false));
+        PostMethod method = new PostMethod(submitConfigUrl);
         method.setRequestEntity(new FileRequestEntity(project.getConfigFile().getFile(),"text/xml"));
         executeMethod(method);
     }


### PR DESCRIPTION
URI(submitConfigUrl,false) in which submitConfigUrl is result of Util.rawEncode() method causes that submitConfigUrl is double encoded (for example & is %2526 instead of %26)
