### PR TITLE
If matrix configuration does not exists, try create it.

### DIFF
--- a/src/main/java/hudson/plugins/build_publisher/HudsonInstance.java
+++ b/src/main/java/hudson/plugins/build_publisher/HudsonInstance.java
@@ -208,7 +208,7 @@ public final class HudsonInstance {
     public synchronized List<AbstractBuild> getQueue() {
         return new ArrayList<AbstractBuild>(publishRequestQueue);
     }
-
+    
     /**
      * Gets the thread that does the publication.
      *


### PR DESCRIPTION
If matrix configuration does not exists in public instance and does not active configuration (configuration of matrix job was changed before publishing process), it is necessary to create it (update matrix configuration does not help in this case)

Do not publish build which has been deleted before publishing process.
