### PR TITLE
Use BASIC authentication so that an API token may be specified

### DIFF
--- a/src/main/resources/hudson/plugins/build_publisher/BuildPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/build_publisher/BuildPublisher/global.jelly
@@ -17,8 +17,9 @@
           <f:entry title="Login" help="/plugin/build-publisher/help/global/login.html">
             <f:textbox name="bp.login" value="${serv.getLogin()}"/>
           </f:entry>
-        
-          <f:entry title="Password" help="/plugin/build-publisher/help/global/password.html">
+
+          <!-- TODO convenience hyperlink to open ${url}/user/${login}/configure where the API token is displayed -->
+          <f:entry title="API Token" help="/plugin/build-publisher/help/global/password.html">
             <input class="setting-input" name="bp.password"
                    type="password" value="${serv.getPassword()}"/>
           </f:entry>

--- a/src/main/webapp/help/global/password.html
+++ b/src/main/webapp/help/global/password.html
@@ -1,3 +1,3 @@
 <div>
-    Password for the above login name. Leave this field empty if this external Hudson is not secured.
+    API token for the above login name. Leave this field empty if this external Jenkins is not secured.
 </div>


### PR DESCRIPTION
Necessary in order to publish to a public server using a security realm not based on `AbstractPasswordBasedSecurityRealm` or its kin; discovered while trying to publish to a *.ci.cloudbees.com host.

One downside is that if someone is currently publishing to a password-based security realm, they will need to switch to their API token after an upgrade in order to continue to authenticate. They ought to do so anyway—it is simpler and more secure—but if this is cause for complaint, it should be possible to keep the existing `password` field and add a separate `apiToken` field, explaining in the UI why you should prefer to migrate to the API token, and use either method of authentication as configured.
