### PR TITLE
[JENKINS-24380] Stop relying on the format of Run.id

### DIFF
--- a/src/main/java/hudson/plugins/build_publisher/HTTPBuildTransmitter.java
+++ b/src/main/java/hudson/plugins/build_publisher/HTTPBuildTransmitter.java
@@ -26,7 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.TimeZone;
 import java.util.logging.Level;
 import org.apache.commons.httpclient.HttpException;
 
@@ -72,8 +71,6 @@ public class HTTPBuildTransmitter implements BuildTransmitter {
             method.setRequestEntity(new FileRequestEntity(tempFile,
                     "application/x-tar"));
             
-            method.setRequestHeader("X-Publisher-Timezone", TimeZone.getDefault().getID());
-            method.setRequestHeader("X-Build-ID", build.getId());
             method.setRequestHeader("X-Build-Number", String.valueOf(build.getNumber()));
 
             executeMethod(method, hudsonInstance);


### PR DESCRIPTION
To be merged ASAP (cf. https://github.com/jenkinsci/jenkins/pull/1379).

Passes tests, though it is hard for me to tell if they are comprehensive enough. Discards the logic to compare timezones between publisher and receiver, which was probably a bad idea anyway; `Run.id` is intended to be a permanent unique identifier which can be referenced from various places.

Also discards numeric symlink creation. These do not exist in core after my change; in older cores, they are optional.