### PR TITLE
More helpful exceptions

### DIFF
--- a/src/main/java/hudson/plugins/build_publisher/HTTPBuildTransmitter.java
+++ b/src/main/java/hudson/plugins/build_publisher/HTTPBuildTransmitter.java
@@ -149,9 +149,18 @@ public class HTTPBuildTransmitter implements BuildTransmitter {
 
             try {
                 login("j_security_check", hudsonInstance);
-            } catch (ServerFailureException e) {
+            } catch (ServerFailureException original) {
                 // Here if the servlet authentication is not available.
-                login("j_acegi_security_check", hudsonInstance);
+                try {
+                    login("j_acegi_security_check", hudsonInstance);
+                } catch (ServerFailureException acegy) {
+                    // Only one of these endpoints is supposed to exists at a time.
+                    // Do not report 404 as the other exception is likely to be more interesting.
+                    throw (acegy.getMethod().getStatusCode() == 404)
+                        ? original
+                        : acegy
+                    ;
+                }
             }
         }
 

--- a/src/main/java/hudson/plugins/build_publisher/PublisherThread.java
+++ b/src/main/java/hudson/plugins/build_publisher/PublisherThread.java
@@ -274,13 +274,8 @@ public class PublisherThread extends Thread {
     }
 
     private void assertUrlExists(String url) throws IOException, ServerFailureException {
-        if (!urlExists(url)) {
-            // wrong address, give up
-            throw new HttpException(url + ": URL doesn't exist");
-        }
+        executeMethod(new PostMethod(url));
     }
-
-    
 
     private boolean urlExists(String url) throws ServerFailureException, IOException {
 


### PR DESCRIPTION
- Do not hide the actual problem behind *URL doesn't exist*.
- If `j_security_check` rejects credentials with `401`, do not report `404` on `j_acegi_security_check`.